### PR TITLE
Fix preprocessor condition for sys/syscall.h

### DIFF
--- a/inc/thread.h
+++ b/inc/thread.h
@@ -16,7 +16,7 @@
 	#include <pthread.h>
 	#include <sched.h>	// sched_yield
 	#include <unistd.h>	// syscall
-	#ifndef RTM_PLATFORM_PS4
+	#if ! RTM_PLATFORM_PS4
 	#include <sys/syscall.h>
 	#endif
 	#include <time.h> // nanosleep


### PR DESCRIPTION
RTM_PLATFORM_PS4 is always defined - it will either be 0 or 1.
Fix the conditional in inc/thread.h to reflect that.